### PR TITLE
Fixed issue with parsing input strings and added extra output to log …

### DIFF
--- a/communication/client_thread.py
+++ b/communication/client_thread.py
@@ -33,15 +33,28 @@ class ClientThread(threading.Thread):
             # Clean up the connection
             self.connection.close()
 
+        
+    def remove_service_symbols(self, data):
+        if "&apos;" in data:
+            data = data.replace('&apos;', '')
+            logging.error(f"After replacement: {data}")
+        elif "&quote;" in data:
+            data = data.replace('&quote;', '')
+            logging.error(f"After replacement: {data}")
+        return data
+
+
     def parse_request(self, data):
         config_id_size = int(data[1:3].hex(), 16)
 
         if config_id_size == 0:
             data_str = data[6:].decode('utf-8')
+            data_str = self.remove_service_symbols(data_str)
             response = self.config_m.parse_general(data_str)
         else:
             config_id = data[3: config_id_size + 3].decode('utf-8')
             data_str = data[config_id_size + 3 + 3:].decode('utf-8')
+            data_str = self.remove_service_symbols(data_str)
             response = self.config_m.parse_configuration(data_str, config_id)
 
         return response

--- a/core/configuration.py
+++ b/core/configuration.py
@@ -87,6 +87,7 @@ class Configuration:
 
             self.set_fb(fb_name, fb_element)
             logging.info('created fb type: {0}, instance: {1}'.format(fb_type, fb_name))
+            logging.error("List of existing blocks: %s" % self.fb_dictionary)
             # returns the both elements
             return fb_element, fb_definition
         else:
@@ -142,12 +143,14 @@ class Configuration:
         logging.info('watch deleted between {0} and {1}'.format(source, destination))
 
     def write_connection(self, source_value, destination):
-        logging.info('writing a connection...')
+        logging.error('writing a connection...')
+        logging.error(f"SRC: {source_value} DST {destination}")
         destination_attr = destination.split(sep='.')
         destination_fb = self.get_fb(destination_attr[0])
         destination_name = destination_attr[1]
 
         v_type, value, is_watch = destination_fb.read_attr(destination_name)
+        logging.error("Event recived!!!!!!!!!!!!!!!!!")
 
         # Verifies if is to write an event
         if source_value == '$e':
@@ -163,6 +166,8 @@ class Configuration:
         else:
             logging.info('writing a hardcoded value...')
             value_to_set = self.convert_type(source_value, v_type)
+            logging.error(f"Data conversion:\n SRC: {source_value}\nType:{v_type}\n Converted value: {value_to_set} DST:{destination_name}")
+
             destination_fb.set_attr(destination_name, value_to_set)
 
         logging.info('connection ({0}) configured with the value {1}'.format(destination, source_value))

--- a/core/fb_interface.py
+++ b/core/fb_interface.py
@@ -297,11 +297,12 @@ class FBInterface:
                     else:
                         logging.error("doesn't expected interface (check interface name in .fbt file)")
 
-        logging.info('parsing successful with:')
-        logging.info('input events: {0}'.format(self.input_events))
-        logging.info('output events: {0}'.format(self.output_events))
-        logging.info('input vars: {0}'.format(self.input_vars))
-        logging.info('output vars: {0}'.format(self.output_vars))
+        logging.info('Parsing successful with:')
+        logging.info('\t input events: {0}'.format(self.input_events))
+        logging.info('\t output events: {0}'.format(self.output_events))
+        logging.info('\t input vars: {0}'.format(self.input_vars))
+        logging.info('\t output vars: {0}'.format(self.output_vars))
+        logging.info('End of parsing info')
 
         self.output_connections = dict()
 
@@ -526,7 +527,7 @@ class FBInterface:
         return events_list + vars_list
 
     def update_outputs(self, outputs):
-        logging.info('updating the outputs...')
+        logging.error(f'Updating the outputs:{outputs}')
 
         # Converts the second part of the list to variables
         for index, var_name in enumerate(self.output_vars):


### PR DESCRIPTION
In the last version of 4diac IDE usage string works with single and double quotes. During parsing input request from 4diac  system receives following line: 
`<Request ID="4" Action="WRITE"><Connection Source="&apos;234,43244,234,42&apos;" Destination="WRITE_CSV.Data" /></Request>`
The semicolon breaks request, hence also breaks fboot file with deployment info produced by [parser](https://github.com/fronos/dinasore/blob/0615cc05b77fa035478ef4de559e969ed154722f/core/manager.py#L44).